### PR TITLE
update deprecated method call

### DIFF
--- a/OTSecurity/OTHashHelper.m
+++ b/OTSecurity/OTHashHelper.m
@@ -13,7 +13,6 @@
 + (NSString *)hexStringWithData:(NSData *)hashData
 {
     unsigned char *buffer = (unsigned char *)malloc(sizeof(unsigned char) * hashData.length);
-	[hashData getBytes:buffer];
     [hashData getBytes:buffer length:hashData.length];
 	NSMutableString *hashString = [NSMutableString string];
 	for (int i =0 ; i < hashData.length; i++)

--- a/OTSecurity/OTHashHelper.m
+++ b/OTSecurity/OTHashHelper.m
@@ -14,6 +14,7 @@
 {
     unsigned char *buffer = (unsigned char *)malloc(sizeof(unsigned char) * hashData.length);
 	[hashData getBytes:buffer];
+    [hashData getBytes:buffer length:hashData.length];
 	NSMutableString *hashString = [NSMutableString string];
 	for (int i =0 ; i < hashData.length; i++)
     {


### PR DESCRIPTION
use getBytes:length: instead of getBytes: which is deprecated in ios8.0